### PR TITLE
Shape header size should be added to the offset in index file

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -159,7 +159,7 @@ impl<T: Write> Writer<T> {
             rc_hdr.write_to(&mut self.dest)?;
             shapetype.write_to(&mut self.dest)?;
             shape.write_to(&mut self.dest)?;
-            pos += record_size as i32;
+            pos += record_size as i32 + RecordHeader::SIZE as i32 / 2;
         }
 
         if let Some(ref mut shx_dest) = &mut self.index_dest {


### PR DESCRIPTION
Hi there,

Minor fix for the shapefile index. Again I did some investigations for this issue and here is the fix.

FYI, I'm using your project for [Joxit/wof-cli](https://github.com/Joxit/wof-cli) and it's promising :smile: 