### PR TITLE
Each Shape that has multiple points has a BBox

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,14 +10,22 @@
 //! 2) Reading directly as concrete shapes (ie Polyline, PolylineZ, Point, etc) this of course only
 //! works if the file actually contains shapes that matches the requested type
 //!
+//! # Shapefiles shapes
+//!
+//! The [`Point`], [`PointM`] and [`PointZ`] are the base data types of shapefiles,
+//! the other shapes (`Polyline, Multipoint`, ...) are collections of these type of points
+//! with different semantics (multiple parts or no, closed parts or no, ...)
+//!
+//! With the exception of the [`Multipatch`] shape, each shape as a variant for each type
+//! of point. ([`Multipatch`] always uses [`PointZ`])
+//! Eg: For the polyline, there is [`Polyline`], [`PolylineM`], [`PolylineZ`]
+//!
 //! # Reading
 //! For more details see the [reader](reader/index.html) module
-//!
 //!
 //! # Writing
 //!
 //! To write a file see the [writer](writer/index.html) module
-//!
 //!
 //!
 //! # Features

--- a/src/record/bbox.rs
+++ b/src/record/bbox.rs
@@ -1,0 +1,110 @@
+///! Bounding Boxes
+use record::traits::{GrowablePoint, HasM, HasXY, HasZ, ShrinkablePoint};
+use record::EsriShape;
+use writer::{f64_max, f64_min};
+use PointZ;
+
+/// The Bounding Box type used in this crate.
+///
+/// Each shape that is a collection of points have a bounding box
+/// associated to it generally accessible using the `bbox()` method.
+///
+/// # Example
+///
+/// ```
+/// use shapefile::{PointM, PolylineM};
+/// let poly = PolylineM::new(vec![
+///     PointM::new(1.0, 2.0, 13.42),
+///     PointM::new(2.0, 1.0, 42.3713),
+/// ]);
+///
+/// let bbox = poly.bbox();
+/// assert_eq!(bbox.min, PointM::new(1.0, 1.0, 13.42));
+/// assert_eq!(bbox.max, PointM::new(2.0, 2.0, 42.3713));
+/// ```
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct GenericBBox<PointType> {
+    pub max: PointType,
+    pub min: PointType,
+}
+
+impl<PointType> GenericBBox<PointType> {
+    pub(crate) fn from_points(points: &[PointType]) -> Self
+    where
+        PointType: Copy + ShrinkablePoint + GrowablePoint,
+    {
+        let mut min_point = points[0];
+        let mut max_point = points[0];
+
+        for point in &points[1..] {
+            min_point.shrink(point);
+            max_point.grow(point);
+        }
+
+        Self {
+            max: max_point,
+            min: min_point,
+        }
+    }
+}
+
+impl<PointType: HasXY> GenericBBox<PointType> {
+    pub fn x_range(&self) -> [f64; 2] {
+        [self.min.x(), self.max.x()]
+    }
+
+    pub fn y_range(&self) -> [f64; 2] {
+        [self.min.y(), self.max.y()]
+    }
+}
+
+impl<PointType: HasZ> GenericBBox<PointType> {
+    pub fn z_range(&self) -> [f64; 2] {
+        [self.min.z(), self.max.z()]
+    }
+}
+
+impl<PointType: HasM> GenericBBox<PointType> {
+    pub fn m_range(&self) -> [f64; 2] {
+        [self.min.m(), self.max.m()]
+    }
+}
+
+impl<PointType: Default> Default for GenericBBox<PointType> {
+    fn default() -> Self {
+        Self {
+            max: PointType::default(),
+            min: PointType::default(),
+        }
+    }
+}
+
+pub type BBoxZ = GenericBBox<PointZ>;
+
+impl BBoxZ {
+    pub(crate) fn from_shapes<S: EsriShape>(shapes: &[S]) -> Self {
+        use std::f64::{MAX, MIN};
+        let mut bbox = Self {
+            max: PointZ::new(MIN, MIN, MIN, MIN),
+            min: PointZ::new(MAX, MAX, MAX, MAX),
+        };
+
+        for shape in shapes {
+            let x_range = shape.x_range();
+            let y_range = shape.y_range();
+            let z_range = shape.z_range();
+            let m_range = shape.m_range();
+
+            bbox.min.x = f64_min(x_range[0], bbox.min.x);
+            bbox.min.y = f64_min(y_range[0], bbox.min.y);
+            bbox.min.z = f64_min(z_range[0], bbox.min.z);
+            bbox.min.m = f64_min(m_range[0], bbox.min.m);
+
+            bbox.max.x = f64_max(x_range[1], bbox.max.x);
+            bbox.max.y = f64_max(y_range[1], bbox.max.y);
+            bbox.max.z = f64_max(z_range[1], bbox.max.z);
+            bbox.max.m = f64_max(m_range[1], bbox.max.m);
+        }
+        bbox
+    }
+}

--- a/src/record/point.rs
+++ b/src/record/point.rs
@@ -5,13 +5,13 @@ use std::io::{Read, Write};
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use record::EsriShape;
 use std::mem::size_of;
-use ::{ShapeType, NO_DATA};
+use {ShapeType, NO_DATA};
 
 use super::Error;
-use record::ConcreteReadableShape;
-use record::{is_no_data, BBox, HasShapeType, WritableShape};
-use std::fmt;
 use crate::record::traits::MultipointShape;
+use record::ConcreteReadableShape;
+use record::{is_no_data, HasShapeType, WritableShape};
+use std::fmt;
 
 #[cfg(feature = "geo-types")]
 use geo_types;
@@ -30,7 +30,6 @@ macro_rules! impl_multipoint_shape_for (
         }
     }
 );
-
 
 /// Point with only `x` and `y` coordinates
 #[derive(PartialEq, Debug, Default, Copy, Clone)]
@@ -93,13 +92,12 @@ impl WritableShape for Point {
 }
 
 impl EsriShape for Point {
-    fn bbox(&self) -> BBox {
-        BBox {
-            xmin: self.x,
-            ymin: self.y,
-            xmax: self.x,
-            ymax: self.y,
-        }
+    fn x_range(&self) -> [f64; 2] {
+        [self.x, self.x]
+    }
+
+    fn y_range(&self) -> [f64; 2] {
+        [self.y, self.y]
     }
 }
 
@@ -128,20 +126,16 @@ impl From<geo_types::Point<f64>> for Point {
 #[cfg(feature = "geo-types")]
 impl From<geo_types::Coordinate<f64>> for Point {
     fn from(c: geo_types::Coordinate<f64>) -> Self {
-        Point::new(c.x,c.y)
+        Point::new(c.x, c.y)
     }
 }
 
 #[cfg(feature = "geo-types")]
 impl From<Point> for geo_types::Coordinate<f64> {
     fn from(p: Point) -> Self {
-        geo_types::Coordinate{
-            x:p.x,
-            y: p.y
-        }
+        geo_types::Coordinate { x: p.x, y: p.y }
     }
 }
-
 
 /*
  * PointM
@@ -205,13 +199,12 @@ impl WritableShape for PointM {
 }
 
 impl EsriShape for PointM {
-    fn bbox(&self) -> BBox {
-        BBox {
-            xmin: self.x,
-            ymin: self.y,
-            xmax: self.x,
-            ymax: self.y,
-        }
+    fn x_range(&self) -> [f64; 2] {
+        [self.x, self.x]
+    }
+
+    fn y_range(&self) -> [f64; 2] {
+        [self.y, self.y]
     }
 
     fn m_range(&self) -> [f64; 2] {
@@ -238,13 +231,12 @@ impl Default for PointM {
         Self {
             x: 0.0,
             y: 0.0,
-            m: NO_DATA
+            m: NO_DATA,
         }
     }
 }
 
 impl_multipoint_shape_for!(PointM);
-
 
 #[cfg(feature = "geo-types")]
 impl From<PointM> for geo_types::Point<f64> {
@@ -256,28 +248,27 @@ impl From<PointM> for geo_types::Point<f64> {
 #[cfg(feature = "geo-types")]
 impl From<geo_types::Point<f64>> for PointM {
     fn from(p: geo_types::Point<f64>) -> Self {
-        PointM{x: p.x(), y: p.y(), ..Default::default()}
+        PointM {
+            x: p.x(),
+            y: p.y(),
+            ..Default::default()
+        }
     }
 }
 
 #[cfg(feature = "geo-types")]
 impl From<geo_types::Coordinate<f64>> for PointM {
     fn from(c: geo_types::Coordinate<f64>) -> Self {
-        PointM::new(c.x,c.y, NO_DATA)
+        PointM::new(c.x, c.y, NO_DATA)
     }
 }
 
 #[cfg(feature = "geo-types")]
 impl From<PointM> for geo_types::Coordinate<f64> {
     fn from(p: PointM) -> Self {
-        geo_types::Coordinate{
-            x:p.x,
-            y: p.y
-        }
+        geo_types::Coordinate { x: p.x, y: p.y }
     }
 }
-
-
 
 /*
  * PointZ
@@ -313,7 +304,12 @@ impl PointZ {
         let x = source.read_f64::<LittleEndian>()?;
         let y = source.read_f64::<LittleEndian>()?;
         let z = source.read_f64::<LittleEndian>()?;
-        Ok(Self { x, y, z, m: NO_DATA })
+        Ok(Self {
+            x,
+            y,
+            z,
+            m: NO_DATA,
+        })
     }
 }
 
@@ -353,13 +349,12 @@ impl WritableShape for PointZ {
 }
 
 impl EsriShape for PointZ {
-    fn bbox(&self) -> BBox {
-        BBox {
-            xmin: self.x,
-            ymin: self.y,
-            xmax: self.x,
-            ymax: self.y,
-        }
+    fn x_range(&self) -> [f64; 2] {
+        [self.x, self.x]
+    }
+
+    fn y_range(&self) -> [f64; 2] {
+        [self.y, self.y]
     }
 
     fn z_range(&self) -> [f64; 2] {
@@ -381,7 +376,7 @@ impl Default for PointZ {
             x: 0.0,
             y: 0.0,
             z: 0.0,
-            m: NO_DATA
+            m: NO_DATA,
         }
     }
 }
@@ -416,28 +411,27 @@ impl From<PointZ> for geo_types::Point<f64> {
 #[cfg(feature = "geo-types")]
 impl From<geo_types::Point<f64>> for PointZ {
     fn from(p: geo_types::Point<f64>) -> Self {
-        PointZ{x: p.x(), y: p.y(), ..Default::default()}
+        PointZ {
+            x: p.x(),
+            y: p.y(),
+            ..Default::default()
+        }
     }
 }
-
 
 #[cfg(feature = "geo-types")]
 impl From<geo_types::Coordinate<f64>> for PointZ {
     fn from(c: geo_types::Coordinate<f64>) -> Self {
-        PointZ::new(c.x,c.y, 0.0, NO_DATA)
+        PointZ::new(c.x, c.y, 0.0, NO_DATA)
     }
 }
 
 #[cfg(feature = "geo-types")]
 impl From<PointZ> for geo_types::Coordinate<f64> {
     fn from(p: PointZ) -> Self {
-        geo_types::Coordinate {
-            x: p.x,
-            y: p.y
-        }
+        geo_types::Coordinate { x: p.x, y: p.y }
     }
 }
-
 
 #[cfg(test)]
 #[cfg(feature = "geo-types")]

--- a/src/record/poly.rs
+++ b/src/record/poly.rs
@@ -8,11 +8,11 @@ use std::slice::SliceIndex;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 
 use record::io::*;
-use record::{is_parts_array_valid, close_points_if_not_already};
-use record::traits::HasXY;
+use record::traits::{GrowablePoint, HasXY, ShrinkablePoint};
 use record::traits::{MultipartShape, MultipointShape};
 use record::ConcreteReadableShape;
-use record::{BBox, EsriShape, HasShapeType, WritableShape};
+use record::{close_points_if_not_already, is_parts_array_valid, GenericBBox};
+use record::{EsriShape, HasShapeType, WritableShape};
 use record::{Point, PointM, PointZ};
 use {Error, ShapeType};
 
@@ -21,15 +21,24 @@ use geo_types;
 #[cfg(feature = "geo-types")]
 use std::convert::TryFrom;
 
+/// Generic struct to create Polyline; PolylineM, PolylineZ
+///
+/// Polylines can have multiple parts.
+///
+/// To create a polyline with only one part use [`new`],
+/// to create a polyline with multiple parts use [`with_parts`]
+///
+/// [`new`]: #method.new
+/// [`with_parts`]: #method.with_parts
 #[derive(Debug, Clone, PartialEq)]
 pub struct GenericPolyline<PointType> {
-    pub bbox: BBox,
-    pub points: Vec<PointType>,
-    pub parts: Vec<i32>,
+    bbox: GenericBBox<PointType>,
+    points: Vec<PointType>,
+    parts: Vec<i32>,
 }
 
 /// Creating a Polyline
-impl<PointType: HasXY> GenericPolyline<PointType> {
+impl<PointType: ShrinkablePoint + GrowablePoint + Copy> GenericPolyline<PointType> {
     /// # Examples
     ///
     /// Polyline with single part
@@ -40,15 +49,11 @@ impl<PointType: HasXY> GenericPolyline<PointType> {
     ///     Point::new(2.0, 2.0),
     /// ];
     /// let poly = Polyline::new(points);
-    ///
-    /// assert_eq!(poly.points.len(), 2);
-    /// assert_eq!(poly.parts, vec![0]);
     /// ```
     ///
     pub fn new(points: Vec<PointType>) -> Self {
-        let bbox = BBox::from_points(&points);
         Self {
-            bbox,
+            bbox: GenericBBox::<PointType>::from_points(&points),
             points,
             parts: vec![0],
         }
@@ -63,6 +68,7 @@ impl<PointType: HasXY> GenericPolyline<PointType> {
     ///     Point::new(1.0, 1.0),
     ///     Point::new(2.0, 2.0),
     /// ];
+    ///
     /// let second_part = vec![
     ///     Point::new(3.0, 1.0),
     ///     Point::new(5.0, 6.0),
@@ -74,20 +80,17 @@ impl<PointType: HasXY> GenericPolyline<PointType> {
     ///     Point::new(20.0, 19.0),
     /// ];
     /// let poly = Polyline::with_parts(vec![first_part, second_part, third_part]);
-    ///
-    /// assert_eq!(poly.points.len(), 7);
-    /// assert_eq!(poly.parts, vec![0, 2, 4]);
     /// ```
     ///
     pub fn with_parts(parts: Vec<Vec<PointType>>) -> Self {
         let mut parts_indices = Vec::<i32>::with_capacity(parts.len());
         parts_indices.push(0);
         if let Some(following_parts) = parts.get(1..parts.len()) {
-           let mut sum = parts[0].len() as i32;
-           for points in  following_parts {
+            let mut sum = parts[0].len() as i32;
+            for points in following_parts {
                 parts_indices.push(sum);
                 sum += points.len() as i32;
-           }
+            }
         }
 
         let num_points = parts.iter().map(|pts| pts.len()).sum();
@@ -96,15 +99,20 @@ impl<PointType: HasXY> GenericPolyline<PointType> {
             all_points.append(&mut points);
         }
 
-        let bbox = BBox::from_points(&all_points);
         Self {
-            bbox,
+            bbox: GenericBBox::<PointType>::from_points(&all_points),
             points: all_points,
             parts: parts_indices,
         }
     }
 }
 
+impl<PointType> GenericPolyline<PointType> {
+    /// Returns the bounding box associated to the polyline
+    pub fn bbox(&self) -> &GenericBBox<PointType> {
+        &self.bbox
+    }
+}
 
 impl<PointType> From<GenericPolygon<PointType>> for GenericPolyline<PointType> {
     fn from(p: GenericPolygon<PointType>) -> Self {
@@ -144,30 +152,31 @@ impl<PointType> MultipartShape<PointType> for GenericPolyline<PointType> {
     }
 }
 
-
 #[cfg(feature = "geo-types")]
 impl<PointType> From<GenericPolyline<PointType>> for geo_types::MultiLineString<f64>
-    where PointType: Copy,
-         geo_types::Coordinate<f64>: From<PointType>
-    {
+where
+    PointType: Copy,
+    geo_types::Coordinate<f64>: From<PointType>,
+{
     fn from(polyline: GenericPolyline<PointType>) -> Self {
         use std::iter::FromIterator;
-        let mut lines = Vec::<geo_types::LineString<f64>>::with_capacity(polyline.parts_indices().len());
+        let mut lines =
+            Vec::<geo_types::LineString<f64>>::with_capacity(polyline.parts_indices().len());
         for parts in polyline.parts() {
-            let line: Vec<geo_types::Coordinate<f64>> =
-                parts.iter()
-                    .map(|point| geo_types::Coordinate::<f64>::from(*point))
-                    .collect();
+            let line: Vec<geo_types::Coordinate<f64>> = parts
+                .iter()
+                .map(|point| geo_types::Coordinate::<f64>::from(*point))
+                .collect();
             lines.push(line.into());
         }
         geo_types::MultiLineString::<f64>::from_iter(lines.into_iter())
     }
 }
 
-
 #[cfg(feature = "geo-types")]
 impl<PointType> From<geo_types::Line<f64>> for GenericPolyline<PointType>
-    where PointType: From<geo_types::Point<f64>> + HasXY
+where
+    PointType: From<geo_types::Point<f64>> + HasXY,
 {
     fn from(line: geo_types::Line<f64>) -> Self {
         let (p1, p2) = line.points();
@@ -175,25 +184,21 @@ impl<PointType> From<geo_types::Line<f64>> for GenericPolyline<PointType>
     }
 }
 
-
 #[cfg(feature = "geo-types")]
 impl<PointType> From<geo_types::LineString<f64>> for GenericPolyline<PointType>
-    where PointType: From<geo_types::Coordinate<f64>> + HasXY
+where
+    PointType: From<geo_types::Coordinate<f64>> + HasXY,
 {
     fn from(line: geo_types::LineString<f64>) -> Self {
-        let points: Vec<PointType> = line
-            .into_iter()
-            .map(|p| PointType::from(p))
-            .collect();
+        let points: Vec<PointType> = line.into_iter().map(|p| PointType::from(p)).collect();
         Self::new(points)
     }
 }
 
-
-
 #[cfg(feature = "geo-types")]
 impl<PointType> From<geo_types::MultiLineString<f64>> for GenericPolyline<PointType>
-    where PointType: From<geo_types::Coordinate<f64>> + HasXY
+where
+    PointType: From<geo_types::Coordinate<f64>> + HasXY,
 {
     fn from(mls: geo_types::MultiLineString<f64>) -> Self {
         let mut points = Vec::<PointType>::new();
@@ -210,7 +215,7 @@ impl<PointType> From<geo_types::MultiLineString<f64>> for GenericPolyline<PointT
         Self {
             bbox,
             points,
-            parts
+            parts,
         }
     }
 }
@@ -248,7 +253,8 @@ impl HasShapeType for Polyline {
 
 impl ConcreteReadableShape for Polyline {
     fn read_shape_content<T: Read>(mut source: &mut T, record_size: i32) -> Result<Self, Error> {
-        let bbox = BBox::read_from(&mut source)?;
+        let mut bbox = GenericBBox::<Point>::default();
+        bbox_read_xy_from(&mut bbox, source)?;
         let num_parts = source.read_i32::<LittleEndian>()?;
         let num_points = source.read_i32::<LittleEndian>()?;
 
@@ -282,7 +288,7 @@ impl WritableShape for Polyline {
         if !is_parts_array_valid(&self) {
             return Err(Error::MalformedShape);
         }
-        self.bbox.write_to(&mut dest)?;
+        bbox_write_xy_to(&self.bbox, dest)?;
         dest.write_i32::<LittleEndian>(self.parts.len() as i32)?;
         dest.write_i32::<LittleEndian>(self.points.len() as i32)?;
         write_parts(&mut dest, &self.parts)?;
@@ -292,8 +298,12 @@ impl WritableShape for Polyline {
 }
 
 impl EsriShape for Polyline {
-    fn bbox(&self) -> BBox {
-        self.bbox
+    fn x_range(&self) -> [f64; 2] {
+        self.bbox.x_range()
+    }
+
+    fn y_range(&self) -> [f64; 2] {
+        self.bbox.y_range()
     }
 }
 
@@ -333,7 +343,8 @@ impl HasShapeType for PolylineM {
 
 impl ConcreteReadableShape for PolylineM {
     fn read_shape_content<T: Read>(mut source: &mut T, record_size: i32) -> Result<Self, Error> {
-        let bbox = BBox::read_from(&mut source)?;
+        let mut bbox = GenericBBox::<PointM>::default();
+        bbox_read_xy_from(&mut bbox, source)?;
         let num_parts = source.read_i32::<LittleEndian>()?;
         let num_points = source.read_i32::<LittleEndian>()?;
 
@@ -349,7 +360,7 @@ impl ConcreteReadableShape for PolylineM {
             let mut points = read_xy_in_vec_of::<PointM, T>(&mut source, num_points)?;
 
             if is_m_used {
-                let _m_range = read_range(&mut source)?;
+                bbox_read_m_range_from(&mut bbox, source)?;
                 read_ms_into(&mut source, &mut points)?;
             }
 
@@ -378,25 +389,29 @@ impl WritableShape for PolylineM {
         if !is_parts_array_valid(&self) {
             return Err(Error::MalformedShape);
         }
-        self.bbox.write_to(&mut dest)?;
+        bbox_write_xy_to(&self.bbox, dest)?;
         dest.write_i32::<LittleEndian>(self.parts.len() as i32)?;
         dest.write_i32::<LittleEndian>(self.points.len() as i32)?;
         write_parts(&mut dest, &self.parts)?;
         write_points(&mut dest, &self.points)?;
 
-        write_range(&mut dest, self.m_range())?;
+        bbox_write_m_range_to(&self.bbox, dest)?;
         write_ms(&mut dest, &self.points)?;
         Ok(())
     }
 }
 
 impl EsriShape for PolylineM {
-    fn bbox(&self) -> BBox {
-        self.bbox
+    fn x_range(&self) -> [f64; 2] {
+        self.bbox.x_range()
+    }
+
+    fn y_range(&self) -> [f64; 2] {
+        self.bbox.y_range()
     }
 
     fn m_range(&self) -> [f64; 2] {
-        calc_m_range(&self.points)
+        self.bbox.m_range()
     }
 }
 
@@ -438,7 +453,8 @@ impl HasShapeType for PolylineZ {
 
 impl ConcreteReadableShape for PolylineZ {
     fn read_shape_content<T: Read>(mut source: &mut T, record_size: i32) -> Result<Self, Error> {
-        let bbox = BBox::read_from(&mut source)?;
+        let mut bbox = GenericBBox::<PointZ>::default();
+        bbox_read_xy_from(&mut bbox, source)?;
         let num_parts = source.read_i32::<LittleEndian>()?;
         let num_points = source.read_i32::<LittleEndian>()?;
 
@@ -453,11 +469,11 @@ impl ConcreteReadableShape for PolylineZ {
 
             let mut points = read_xy_in_vec_of::<PointZ, T>(&mut source, num_points)?;
 
-            let _z_range = read_range(&mut source)?;
+            bbox_read_z_range_from(&mut bbox, source)?;
             read_zs_into(&mut source, &mut points)?;
 
             if is_m_used {
-                let _m_range = read_range(&mut source)?;
+                bbox_read_m_range_from(&mut bbox, source)?;
                 read_ms_into(&mut source, &mut points)?;
             }
 
@@ -487,33 +503,37 @@ impl WritableShape for PolylineZ {
         if !is_parts_array_valid(&self) {
             return Err(Error::MalformedShape);
         }
-        self.bbox.write_to(&mut dest)?;
+        bbox_write_xy_to(&self.bbox, dest)?;
         dest.write_i32::<LittleEndian>(self.parts.len() as i32)?;
         dest.write_i32::<LittleEndian>(self.points.len() as i32)?;
         write_parts(&mut dest, &self.parts)?;
 
         write_points(&mut dest, &self.points)?;
 
-        write_range(&mut dest, self.z_range())?;
+        bbox_write_z_range_to(&self.bbox, dest)?;
         write_zs(&mut dest, &self.points)?;
 
-        write_range(&mut dest, self.m_range())?;
+        bbox_write_m_range_to(&self.bbox, dest)?;
         write_ms(&mut dest, &self.points)?;
         Ok(())
     }
 }
 
 impl EsriShape for PolylineZ {
-    fn bbox(&self) -> BBox {
-        self.bbox
+    fn x_range(&self) -> [f64; 2] {
+        self.bbox.x_range()
+    }
+
+    fn y_range(&self) -> [f64; 2] {
+        self.bbox.y_range()
     }
 
     fn z_range(&self) -> [f64; 2] {
-        calc_z_range(&self.points)
+        self.bbox.z_range()
     }
 
     fn m_range(&self) -> [f64; 2] {
-        calc_m_range(&self.points)
+        self.bbox.m_range()
     }
 }
 
@@ -521,15 +541,28 @@ impl EsriShape for PolylineZ {
  * Polygon
  */
 
-
+/// Generic struct to create Polygon; PolygonM, PolygonZ
+///
+/// Polygons can have multiple parts (or rings)
+///
+/// To create a polygon with only one part use [`new`],
+/// to create a polygon with multiple parts use [`with_parts`]
+///
+/// Polygon's rings (parts) must be closed: the first and last point must be the same
+/// the constructors will close your polygon if you did not do it yourself.
+///
+/// [`new`]: #method.new
+/// [`with_parts`]: #method.with_parts
 #[derive(Debug, Clone, PartialEq)]
 pub struct GenericPolygon<PointType> {
-    pub bbox: BBox,
-    pub points: Vec<PointType>,
-    pub parts: Vec<i32>,
+    bbox: GenericBBox<PointType>,
+    points: Vec<PointType>,
+    parts: Vec<i32>,
 }
 
-impl<PointType: HasXY + PartialEq + Copy> GenericPolygon<PointType> {
+impl<PointType: ShrinkablePoint + GrowablePoint + PartialEq + HasXY + Copy>
+    GenericPolygon<PointType>
+{
     /// # Examples
     ///
     /// Creating a PolygonZ with one ring,
@@ -542,10 +575,6 @@ impl<PointType: HasXY + PartialEq + Copy> GenericPolygon<PointType> {
     ///     PointZ::new(1.0, 0.0, 0.0, NO_DATA),
     /// ];
     /// let poly = PolygonZ::new(points);
-    ///
-    /// // The polygon gets closed 'explicitly'
-    /// assert_eq!(poly.points.len(), 4);
-    /// assert_eq!(poly.points.last(), poly.points.first());
     /// ```
     ///
     pub fn new(mut points: Vec<PointType>) -> Self {
@@ -557,12 +586,25 @@ impl<PointType: HasXY + PartialEq + Copy> GenericPolygon<PointType> {
     }
 }
 
-impl<PointType: HasXY + PartialEq + Copy> GenericPolygon<PointType> {
+impl<PointType> GenericPolygon<PointType> {
+    /// Returns the bounding box associated to the polygon
+    pub fn bbox(&self) -> &GenericBBox<PointType> {
+        &self.bbox
+    }
+}
+
+impl<PointType: GrowablePoint + ShrinkablePoint + PartialEq + HasXY + Copy>
+    GenericPolygon<PointType>
+{
     pub fn with_parts(mut parts_points: Vec<Vec<PointType>>) -> Self {
-        parts_points.iter_mut().for_each(close_points_if_not_already);
+        parts_points
+            .iter_mut()
+            .for_each(close_points_if_not_already);
         let mut has_outer_ring = false;
         for points in &mut parts_points {
-            if super::ring_type_from_points_ordering(&points) == super::RingType::InnerRing && !has_outer_ring {
+            if super::ring_type_from_points_ordering(&points) == super::RingType::InnerRing
+                && !has_outer_ring
+            {
                 points.reverse();
                 has_outer_ring = true;
             }
@@ -597,8 +639,10 @@ impl<PointType> MultipartShape<PointType> for GenericPolygon<PointType> {
 /// Vertices of rings defining holes in polygons are in a counterclockwise direction
 #[cfg(feature = "geo-types")]
 impl<PointType> TryFrom<GenericPolygon<PointType>> for geo_types::MultiPolygon<f64>
-    where PointType: HasXY + Copy,
-          geo_types::Point<f64>: From<PointType>{
+where
+    PointType: HasXY + Copy,
+    geo_types::Point<f64>: From<PointType>,
+{
     type Error = Error;
     fn try_from(p: GenericPolygon<PointType>) -> Result<Self, Self::Error> {
         let mut last_poly = None;
@@ -619,7 +663,7 @@ impl<PointType> TryFrom<GenericPolygon<PointType>> for geo_types::MultiPolygon<f
                 if let Some(ref mut polygon) = last_poly {
                     polygon.interiors_push(points);
                 } else {
-                    return Err(Error::OrphanInnerRing)
+                    return Err(Error::OrphanInnerRing);
                 }
             }
         }
@@ -628,20 +672,25 @@ impl<PointType> TryFrom<GenericPolygon<PointType>> for geo_types::MultiPolygon<f
         }
         Ok(polygons.into())
     }
-
 }
 
 #[cfg(feature = "geo-types")]
 /// geo_types guarantees that Polygons exterior and interiors are closed
 impl<PointType> From<geo_types::Polygon<f64>> for GenericPolygon<PointType>
-    where  PointType: HasXY + From<geo_types::Coordinate<f64>> + PartialEq + Copy {
+where
+    PointType: HasXY + From<geo_types::Coordinate<f64>> + PartialEq + Copy,
+{
     fn from(polygon: geo_types::Polygon<f64>) -> Self {
-        if polygon.exterior(). num_coords() == 0 {
+        if polygon.exterior().num_coords() == 0 {
             return Self::new(vec![]);
         }
 
         let mut total_num_points = polygon.exterior().num_coords();
-        total_num_points += polygon.interiors().iter().map(|ls| ls.num_coords()).sum::<usize>();
+        total_num_points += polygon
+            .interiors()
+            .iter()
+            .map(|ls| ls.num_coords())
+            .sum::<usize>();
 
         let mut all_points = Vec::<PointType>::with_capacity(total_num_points);
 
@@ -677,14 +726,16 @@ impl<PointType> From<geo_types::Polygon<f64>> for GenericPolygon<PointType>
         Self {
             bbox,
             points: all_points,
-            parts
+            parts,
         }
     }
 }
 
 #[cfg(feature = "geo-types")]
 impl<PointType> From<geo_types::MultiPolygon<f64>> for GenericPolygon<PointType>
-    where  PointType: HasXY + From<geo_types::Coordinate<f64>> + PartialEq + Copy {
+where
+    PointType: HasXY + From<geo_types::Coordinate<f64>> + PartialEq + Copy,
+{
     fn from(multi_polygon: geo_types::MultiPolygon<f64>) -> Self {
         let polygons = multi_polygon
             .into_iter()
@@ -710,10 +761,14 @@ impl<PointType> From<geo_types::MultiPolygon<f64>> for GenericPolygon<PointType>
         Self {
             bbox,
             points: all_points,
-            parts
+            parts,
         }
     }
 }
+
+/*
+ * Polygon
+*/
 
 pub type Polygon = GenericPolygon<Point>;
 
@@ -759,8 +814,12 @@ impl WritableShape for Polygon {
 }
 
 impl EsriShape for Polygon {
-    fn bbox(&self) -> BBox {
-        self.bbox
+    fn x_range(&self) -> [f64; 2] {
+        self.bbox.x_range()
+    }
+
+    fn y_range(&self) -> [f64; 2] {
+        self.bbox.y_range()
     }
 }
 
@@ -812,12 +871,16 @@ impl WritableShape for PolygonM {
 }
 
 impl EsriShape for PolygonM {
-    fn bbox(&self) -> BBox {
-        self.bbox
+    fn x_range(&self) -> [f64; 2] {
+        self.bbox.x_range()
+    }
+
+    fn y_range(&self) -> [f64; 2] {
+        self.bbox.y_range()
     }
 
     fn m_range(&self) -> [f64; 2] {
-        calc_m_range(&self.points)
+        self.bbox.m_range()
     }
 }
 
@@ -870,27 +933,19 @@ impl WritableShape for PolygonZ {
 }
 
 impl EsriShape for PolygonZ {
-    fn bbox(&self) -> BBox {
-        self.bbox
+    fn x_range(&self) -> [f64; 2] {
+        self.bbox.x_range()
+    }
+
+    fn y_range(&self) -> [f64; 2] {
+        self.bbox.y_range()
     }
 
     fn z_range(&self) -> [f64; 2] {
-        calc_z_range(&self.points)
+        self.bbox.z_range()
     }
 
     fn m_range(&self) -> [f64; 2] {
-        calc_m_range(&self.points)
+        self.bbox.m_range()
     }
 }
-
-/*
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_size_of_polyline_z() {
-        assert_eq!(PolylineZ::size_of_record(10, 3), 404);
-    }
-}
-*/

--- a/src/record/traits.rs
+++ b/src/record/traits.rs
@@ -1,6 +1,7 @@
 use std::slice::SliceIndex;
 
 use record::{Point, PointM, PointZ};
+use writer::{f64_max, f64_min};
 
 /// Trait to acces the x, and y values of a point
 pub trait HasXY {
@@ -15,9 +16,20 @@ pub(crate) trait HasMutXY {
     fn y_mut(&mut self) -> &mut f64;
 }
 
-pub(crate) trait HasM {
+pub trait HasM {
     fn m(&self) -> f64;
+}
+
+pub(crate) trait HasMutM {
     fn m_mut(&mut self) -> &mut f64;
+}
+
+pub trait HasZ {
+    fn z(&self) -> f64;
+}
+
+pub(crate) trait HasMutZ {
+    fn z_mut(&mut self) -> &mut f64;
 }
 
 /// Trait that allows access to the slice of points of shapes that
@@ -188,7 +200,9 @@ macro_rules! impl_has_m_for {
             fn m(&self) -> f64 {
                 self.m
             }
+        }
 
+        impl HasMutM for $PointType {
             fn m_mut(&mut self) -> &mut f64 {
                 &mut self.m
             }
@@ -206,3 +220,71 @@ impl_has_mut_xy_for!(PointZ);
 
 impl_has_m_for!(PointM);
 impl_has_m_for!(PointZ);
+
+impl HasZ for PointZ {
+    fn z(&self) -> f64 {
+        self.z
+    }
+}
+
+impl HasMutZ for PointZ {
+    fn z_mut(&mut self) -> &mut f64 {
+        &mut self.z
+    }
+}
+
+pub trait ShrinkablePoint {
+    fn shrink(&mut self, other: &Self);
+}
+
+pub trait GrowablePoint {
+    fn grow(&mut self, other: &Self);
+}
+
+impl ShrinkablePoint for Point {
+    fn shrink(&mut self, other: &Self) {
+        self.x = f64_min(self.x, other.x);
+        self.y = f64_min(self.y, other.y);
+    }
+}
+
+impl ShrinkablePoint for PointM {
+    fn shrink(&mut self, other: &Self) {
+        self.x = f64_min(self.x, other.x);
+        self.y = f64_min(self.y, other.y);
+        self.m = f64_min(self.m, other.m);
+    }
+}
+
+impl ShrinkablePoint for PointZ {
+    fn shrink(&mut self, other: &Self) {
+        self.x = f64_min(self.x, other.x);
+        self.y = f64_min(self.y, other.y);
+        self.z = f64_min(self.z, other.z);
+        self.m = f64_min(self.m, other.m);
+    }
+}
+
+impl GrowablePoint for Point {
+    fn grow(&mut self, other: &Self) {
+        self.x = f64_max(self.x, other.x);
+        self.y = f64_max(self.y, other.y);
+    }
+}
+
+impl GrowablePoint for PointM {
+    fn grow(&mut self, other: &Self) {
+        self.x = f64_max(self.x, other.x);
+        self.y = f64_max(self.y, other.y);
+        self.m = f64_max(self.m, other.m);
+    }
+}
+
+impl GrowablePoint for PointZ {
+    fn grow(&mut self, other: &Self) {
+        self.x = f64_max(self.x, other.x);
+        self.y = f64_max(self.y, other.y);
+        self.z = f64_max(self.z, other.z);
+        self.m = f64_max(self.m, other.m);
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -7,7 +7,7 @@
 use std::io::{BufWriter, Write};
 
 use header;
-use record::{EsriShape, RecordHeader};
+use record::{BBoxZ, EsriShape, RecordHeader};
 use std::fs::File;
 use std::path::Path;
 use Error;
@@ -15,7 +15,7 @@ use Error;
 use byteorder::{BigEndian, WriteBytesExt};
 use reader::ShapeIndex;
 
-fn f64_min(a: f64, b: f64) -> f64 {
+pub(crate) fn f64_min(a: f64, b: f64) -> f64 {
     if a < b {
         a
     } else {
@@ -23,7 +23,7 @@ fn f64_min(a: f64, b: f64) -> f64 {
     }
 }
 
-fn f64_max(a: f64, b: f64) -> f64 {
+pub(crate) fn f64_max(a: f64, b: f64) -> f64 {
     if a > b {
         a
     } else {
@@ -100,40 +100,11 @@ impl<T: Write> Writer<T> {
 
         assert!(file_length <= i32::max_value() as usize);
 
-        let mut point_min = [std::f64::MAX, std::f64::MAX, std::f64::MAX];
-        let mut point_max = [std::f64::MIN, std::f64::MIN, std::f64::MIN];
-        let mut m_range = [0.0, 0.0];
-        for shape in &shapes {
-            let bbox = shape.bbox();
-            let z_range = shape.z_range();
-            point_min[0] = f64_min(point_min[0], bbox.xmin);
-            point_min[1] = f64_min(point_min[1], bbox.ymin);
-            point_min[2] = f64_min(point_min[2], z_range[0]);
-
-            point_max[0] = f64_max(point_max[0], bbox.xmax);
-            point_max[1] = f64_max(point_max[1], bbox.ymax);
-            point_max[2] = f64_max(point_max[2], z_range[1]);
-
-            let s_m_range = shape.m_range();
-            m_range[0] = f64_min(m_range[0], s_m_range[0]);
-            m_range[1] = f64_max(m_range[1], s_m_range[1]);
-        }
-
-        if point_min[2] == std::f64::MAX {
-            point_min[2] = 0.0;
-        }
-
-        if point_max[2] == std::f64::MIN {
-            point_max[2] = 0.0;
-        }
-
         let file_length = file_length as i32;
         let shapetype = S::shapetype();
         let header = header::Header {
+            bbox: BBoxZ::from_shapes(&shapes),
             file_length,
-            point_min,
-            point_max,
-            m_range,
             shape_type: shapetype,
             version: 1000,
         };

--- a/tests/read_tests.rs
+++ b/tests/read_tests.rs
@@ -18,9 +18,8 @@ fn check_line<T: Read>(reader: shapefile::Reader<T>) {
         let header = reader.header();
         assert_eq!(header.file_length, 136);
         assert_eq!(header.shape_type, shapefile::ShapeType::Polyline);
-        assert_eq!(header.point_min, [1.0, 1.0, 0.0]);
-        assert_eq!(header.point_max, [5.0, 6.0, 0.0]);
-        assert_eq!(header.m_range, [0.0, 0.0]);
+        assert_eq!(header.bbox.min, PointZ::new(1.0, 1.0, 0.0, 0.0));
+        assert_eq!(header.bbox.max, PointZ::new(5.0, 6.0, 0.0, 0.0));
     }
 
     let shapes = reader.read().unwrap();
@@ -35,19 +34,18 @@ fn check_linem<T: Read>(reader: shapefile::Reader<T>) {
         let header = reader.header();
         assert_eq!(header.file_length, 172);
         assert_eq!(header.shape_type, shapefile::ShapeType::PolylineM);
-        assert_eq!(header.point_min, [1.0, 1.0, 0.0]);
-        assert_eq!(header.point_max, [5.0, 6.0, 0.0]);
-        //assert_eq!(header.m_range, [0.0, 3.0]); //FIXME
+        assert_eq!(header.bbox.min, PointZ::new(1.0, 1.0, 0.0, 0.0));
+        assert_eq!(header.bbox.max, PointZ::new(5.0, 6.0, 0.0, 3.0));
     }
 
     let shapes = reader.read().unwrap();
     assert_eq!(shapes.len(), 1);
 
     if let shapefile::Shape::PolylineM(shape) = &shapes[0] {
-        assert_eq!(shape.bbox.xmin, 1.0);
-        assert_eq!(shape.bbox.ymin, 1.0);
-        assert_eq!(shape.bbox.xmax, 5.0);
-        assert_eq!(shape.bbox.ymax, 6.0);
+        assert_eq!(shape.bbox().min.x, 1.0);
+        assert_eq!(shape.bbox().min.y, 1.0);
+        assert_eq!(shape.bbox().max.x, 5.0);
+        assert_eq!(shape.bbox().max.y, 6.0);
         assert_eq!(shape.parts_indices(), vec![0, 5].as_slice());
         let expected_points = vec![
             PointM {
@@ -98,9 +96,8 @@ fn check_linez<T: Read>(reader: shapefile::Reader<T>) {
         let header = reader.header();
         assert_eq!(header.file_length, 258);
         assert_eq!(header.shape_type, shapefile::ShapeType::PolylineZ);
-        assert_eq!(header.point_min, [1.0, 1.0, 0.0]);
-        assert_eq!(header.point_max, [5.0, 9.0, 22.0]);
-        assert_eq!(header.m_range, [0.0, 3.0]);
+        assert_eq!(header.bbox.min, PointZ::new(1.0, 1.0, 0.0, 0.0));
+        assert_eq!(header.bbox.max, PointZ::new(5.0, 9.0, 22.0, 3.0));
     }
 
     let shapes = reader.read().unwrap();
@@ -190,9 +187,8 @@ fn check_point<T: Read>(reader: shapefile::Reader<T>) {
         let header = reader.header();
         assert_eq!(header.file_length, 64);
         assert_eq!(header.shape_type, shapefile::ShapeType::Point);
-        assert_eq!(header.point_min, [122.0, 37.0, 0.0]);
-        assert_eq!(header.point_max, [122.0, 37.0, 0.0]);
-        assert_eq!(header.m_range, [0.0, 0.0]);
+        assert_eq!(header.bbox.min, PointZ::new(122.0, 37.0, 0.0, 0.0));
+        assert_eq!(header.bbox.max, PointZ::new(122.0, 37.0, 0.0, 0.0));
     }
     let shapes = reader.read().unwrap();
     assert_eq!(shapes.len(), 1, "Wrong number of shapes");
@@ -237,14 +233,13 @@ fn check_pointm<T: Read>(reader: shapefile::Reader<T>) {
         assert_eq!(header.file_length, 86);
         assert_eq!(header.shape_type, shapefile::ShapeType::PointM);
         assert_eq!(
-            header.point_min,
-            [160467.63787299366, 5403959.561417906, 0.0]
+            header.bbox.min,
+            PointZ::new(160467.63787299366, 5403959.561417906, 0.0, 0.0)
         );
         assert_eq!(
-            header.point_max,
-            [160477.9000324604, 5403971.985031904, 0.0]
+            header.bbox.max,
+            PointZ::new(160477.9000324604, 5403971.985031904, 0.0, 0.0)
         );
-        assert_eq!(header.m_range, [0.0, 0.0]);
     }
     let shapes = reader.read().unwrap();
     assert_eq!(shapes.len(), 2, "Wrong number of shapes");
@@ -273,14 +268,23 @@ fn check_pointz<T: Read>(reader: shapefile::Reader<T>) {
         assert_eq!(header.file_length, 94);
         assert_eq!(header.shape_type, shapefile::ShapeType::PointZ);
         assert_eq!(
-            header.point_min,
-            [1422459.0908050265, 4188942.211755641, 72.40956470558095]
+            header.bbox.min,
+            PointZ::new(
+                1422459.0908050265,
+                4188942.211755641,
+                72.40956470558095,
+                0.0
+            )
         );
         assert_eq!(
-            header.point_max,
-            [1422464.3681007193, 4188962.3364355816, 72.58286959604922]
+            header.bbox.max,
+            PointZ::new(
+                1422464.3681007193,
+                4188962.3364355816,
+                72.58286959604922,
+                0.0
+            )
         );
-        assert_eq!(header.m_range, [0.0, 0.0]);
     }
     let shapes = reader.read().unwrap();
     assert_eq!(shapes.len(), 2, "Wrong number of shapes");
@@ -303,9 +307,8 @@ fn check_polygon<T: Read>(reader: shapefile::Reader<T>) {
         let header = reader.header();
         assert_eq!(header.file_length, 170);
         assert_eq!(header.shape_type, shapefile::ShapeType::Polygon);
-        assert_eq!(header.point_min, [15.0, 2.0, 0.0]);
-        assert_eq!(header.point_max, [122.0, 37.0, 0.0]);
-        assert_eq!(header.m_range, [0.0, 0.0]);
+        assert_eq!(header.bbox.min, PointZ::new(15.0, 2.0, 0.0, 0.0));
+        assert_eq!(header.bbox.max, PointZ::new(122.0, 37.0, 0.0, 0.0));
     }
     let shapes = reader.read().unwrap();
     assert_eq!(shapes.len(), 1, "Wrong number of shapes");
@@ -337,14 +340,13 @@ fn check_polygonm<T: Read>(reader: shapefile::Reader<T>) {
         assert_eq!(header.file_length, 134);
         assert_eq!(header.shape_type, shapefile::ShapeType::PolygonM);
         assert_eq!(
-            header.point_min,
-            [159374.30785312195, 5403473.287488617, 0.0]
+            header.bbox.min,
+            PointZ::new(159374.30785312195, 5403473.287488617, 0.0, 0.0)
         );
         assert_eq!(
-            header.point_max,
-            [160420.36722814097, 5404314.139043656, 0.0]
+            header.bbox.max,
+            PointZ::new(160420.36722814097, 5404314.139043656, 0.0, 0.0)
         );
-        assert_eq!(header.m_range, [0.0, 0.0]);
     }
     let shapes = reader.read().unwrap();
     assert_eq!(shapes.len(), 1, "Wrong number of shapes");
@@ -372,8 +374,6 @@ fn check_polygonm<T: Read>(reader: shapefile::Reader<T>) {
                 m: 0.0,
             },
         ];
-        //assert_eq!(shp.ms, vec![0.0, 0.0, 0.0, 0.0]);
-        //assert_eq!(shp.m_range, [0.0, 0.0]);
         assert_eq!(shp.points(), expected_points.as_slice());
         assert_eq!(shp.parts_indices(), vec![0].as_slice());
     } else {
@@ -396,7 +396,6 @@ fn check_polygonz<T: Read>(reader: shapefile::Reader<T>) {
 
     //FIXME find a file with less values
     if let shapefile::Shape::PolygonZ(shp) = &shapes[0] {
-        //assert_eq!(shp.m_range, [shapefile::NO_DATA, shapefile::NO_DATA]);
         assert_eq!(shp.parts_indices(), vec![0].as_slice());
     } else {
         assert!(false, "The second shape is not a PolygonZ");
@@ -408,9 +407,8 @@ fn check_multipoint<T: Read>(reader: shapefile::Reader<T>) {
         let header = reader.header();
         assert_eq!(header.file_length, 90);
         assert_eq!(header.shape_type, shapefile::ShapeType::Multipoint);
-        assert_eq!(header.point_min, [122.0, 32., 0.0]);
-        assert_eq!(header.point_max, [124.0, 37.0, 0.0]);
-        assert_eq!(header.m_range, [0.0, 0.0]);
+        assert_eq!(header.bbox.min, PointZ::new(122.0, 32., 0.0, 0.0));
+        assert_eq!(header.bbox.max, PointZ::new(124.0, 37.0, 0.0, 0.0));
     }
     let shapes = reader.read().unwrap();
     assert_eq!(shapes.len(), 1, "Wrong number of shapes");
@@ -429,15 +427,23 @@ fn check_multipointz<T: Read>(reader: shapefile::Reader<T>) {
         assert_eq!(header.file_length, 154);
         assert_eq!(header.shape_type, shapefile::ShapeType::MultipointZ);
         assert_eq!(
-            header.point_min,
-            [1422671.7232666016, 4188903.4295959473, 71.99445343017578]
+            header.bbox.min,
+            PointZ::new(
+                1422671.7232666016,
+                4188903.4295959473,
+                71.99445343017578,
+                -1e38
+            )
         );
         assert_eq!(
-            header.point_max,
-            [1422672.1022949219, 4188903.7578430176, 72.00995635986328]
+            header.bbox.max,
+            PointZ::new(
+                1422672.1022949219,
+                4188903.7578430176,
+                72.00995635986328,
+                -1e38
+            )
         );
-        //FIXME Input test file is wrong
-        //assert_eq!(header.m_range, [-1e38, -1e38]);
     }
     let shapes = reader.read().unwrap();
     assert_eq!(shapes.len(), 1, "Wrong number of shapes");
@@ -480,10 +486,9 @@ fn check_multipatch<T: Read>(reader: shapefile::Reader<T>) {
         let header = reader.header();
         assert_eq!(header.file_length, 356, "Wrong file length");
         assert_eq!(header.shape_type, shapefile::ShapeType::Multipatch);
-        assert_eq!(header.point_min, [0.0, 0.0, 0.0]);
-        //FIXME Input test file is wrong
-        //assert_eq!(header.point_max, [5.0, 5.0, 5.0]);
-        //assert_eq!(header.m_range, [0.0, 0.0]);
+        assert_eq!(header.bbox.min, PointZ::new(0.0, 0.0, 0.0, -10e38));
+        // FIXME max z in header of original file is wrong
+        // assert_eq!(header.bbox.max, PointZ::new(5.0, 5.0, 5.0, -10e38));
     }
     use shapefile::NO_DATA;
     let shapes = reader.read().unwrap();
@@ -591,11 +596,12 @@ fn check_multipatch<T: Read>(reader: shapefile::Reader<T>) {
         assert_eq!(shp.points(), expected_points.as_slice());
         assert_eq!(shp.parts_indices(), vec![0, 10].as_slice());
         assert_eq!(
-            shp.parts_type,
+            shp.part_types(),
             vec![
                 shapefile::PatchType::TriangleStrip,
                 shapefile::PatchType::TriangleFan
             ]
+            .as_slice()
         );
     } else {
         assert!(false, "Shape is not a Multipatch");
@@ -655,9 +661,9 @@ read_test!(read_pointm, check_pointm, testfiles::POINTM_PATH);
 read_test!(read_pointz, check_pointz, testfiles::POINTZ_PATH);
 
 /* Read tests on Polygon */
-//read_test!(read_polygon, check_polygon, testfiles::POLYGON_PATH);
+read_test!(read_polygon, check_polygon, testfiles::POLYGON_PATH);
 read_test!(read_polygonm, check_polygonm, testfiles::POLYGONM_PATH);
-//read_test!(read_polygonz, check_polygonz, testfiles::POLYGONZ_PATH);
+read_test!(read_polygonz, check_polygonz, testfiles::POLYGONZ_PATH);
 
 /* Read tests on Multipoint */
 read_test!(

--- a/tests/test_geo_types.rs
+++ b/tests/test_geo_types.rs
@@ -5,8 +5,8 @@ mod geo_types_conversions {
 
     #[test]
     fn test_polygon_conversion() {
-        let shp_polygons = shapefile::read_as::<_, shapefile::Polygon>("tests/data/multi_polygon.shp")
-            .unwrap();
+        let shp_polygons =
+            shapefile::read_as::<_, shapefile::Polygon>("tests/data/multi_polygon.shp").unwrap();
 
         let mut multi_polygons = shp_polygons
             .into_iter()
@@ -14,7 +14,9 @@ mod geo_types_conversions {
             .collect::<Vec<geo_types::MultiPolygon<f64>>>();
 
         let multi_polygon = multi_polygons.pop().unwrap();
-        let geo_polygons = multi_polygon.into_iter().collect::<Vec<geo_types::Polygon<f64>>>();
+        let geo_polygons = multi_polygon
+            .into_iter()
+            .collect::<Vec<geo_types::Polygon<f64>>>();
         assert_eq!(geo_polygons.len(), 4);
         for gp in &geo_polygons {
             assert_eq!(gp.interiors().len(), 0);
@@ -23,8 +25,8 @@ mod geo_types_conversions {
         let multi_polygon = geo_types::MultiPolygon::from(geo_polygons);
         let polygon = shapefile::Polygon::from(multi_polygon);
 
-        let shp_polygons = shapefile::read_as::<_, shapefile::Polygon>("tests/data/multi_polygon.shp")
-            .unwrap();
+        let shp_polygons =
+            shapefile::read_as::<_, shapefile::Polygon>("tests/data/multi_polygon.shp").unwrap();
 
         assert_eq!(&polygon.points, &shp_polygons[0].points);
         assert_eq!(&polygon.parts, &shp_polygons[0].parts);

--- a/tests/testfiles.rs
+++ b/tests/testfiles.rs
@@ -25,10 +25,10 @@ pub const MULTIPATCH_PATH: &str = "./tests/data/multipatch.shp";
 
 pub fn check_line_first_shape(shape: &shapefile::Shape) {
     if let shapefile::Shape::Polyline(shp) = shape {
-        assert_eq!(shp.bbox.xmin, 1.0);
-        assert_eq!(shp.bbox.ymin, 1.0);
-        assert_eq!(shp.bbox.xmax, 5.0);
-        assert_eq!(shp.bbox.ymax, 6.0);
+        assert_eq!(shp.bbox().min.x, 1.0);
+        assert_eq!(shp.bbox().min.y, 1.0);
+        assert_eq!(shp.bbox().max.x, 5.0);
+        assert_eq!(shp.bbox().max.y, 6.0);
         assert_eq!(shp.parts_indices(), vec![0, 5].as_slice());
         let expected_point = vec![
             Point { x: 1.0, y: 5.0 },


### PR DESCRIPTION
Introduce a GenericBoundingBox similar to other *Generic<PointType> struct we already have.

So now,
Polyline, PolylineM, PolylineZ, Polygon, PolygonM, PolygonZ, Multipoint
have a `bbox()` method to get that bbox

Also this makes all the struct members of the shapes private with the exception of Point, PointM, PointZ because it will allow us to change how we implement things & and we don't want the user to mutate the points because the bbox may become 'out of sync'