### PR TITLE
Allow geo-types 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["tests/data/*"]
 [dependencies]
 byteorder = "1.2.7"
 dbase = "0.0.4"
-geo-types = {version = ">=0.4.0, <0.7.0", optional = true}
+geo-types = {version = ">=0.4.0, <0.8.0", optional = true}
 
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
`geo-types` [v0.7.0](https://github.com/georust/geo/releases/tag/geo-types-0.7.0) was just released and shouldn't require any other changes here since you're using `f64` as the coordinate type. More info in the [changelog](https://github.com/georust/geo/blob/master/geo-types/CHANGES.md), let me know if I missed anything!