### PR TITLE
Update dbase-rs to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+ - Updated dbase dependency to 0.1.x
+ - Added a `ShapeReader` &`ShapeWriter` struct that only read/write the .shp and .shx
+ - Changed the `Reader`, it now requires the .dbf to exist
+ - Changed the `Writer`, it requires more information to be able to write the .dbf file
+   (Examples are in the docs)
+ - Changed the `Reader` `iter_*` & `read` to take `&mut self` instead of `self` 
+ - Changed `shapefile::read` now returns a `Vec<(Shape, Record)>` 
+   `shapefile::read_shapes` returns `Vec<Shape>`
+
 # 0.2.2
  - Bumped geo-types optional dependency to allow up to 0.8.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["tests/data/*"]
 
 [dependencies]
 byteorder = "1.2.7"
-dbase = "0.0.4"
+dbase = { git = "https://github.com/tmontaigu/dbase-rs" }
 geo-types = {version = ">=0.4.0, <0.8.0", optional = true}
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 //! Read & Write [Shapefile](http://downloads.esri.com/support/whitepapers/mo_/shapefile.pdf) in Rust
 //!
-//! _.dbf_ can be read & written to (but the support for this is still alpha-ish)
+//! A _shapefile_ is in reality a collection of 3 mandatory files:
+//!  -  .shp (feature geometry aka shapes)
+//!  -  .shx (index of feature geometry)
+//!  -  .dbf (attribute information, aka records)
 //!
 //! As different shapefiles can store different type of shapes
 //! (but one shapefile can only store the same type of shapes)
@@ -54,7 +57,7 @@ use std::convert::From;
 use std::fmt;
 use std::io::{Read, Write};
 
-pub use reader::{read, read_as, Reader};
+pub use reader::{read, read_as, read_shapes, read_shapes_as, ShapeReader, Reader};
 pub use record::Multipatch;
 pub use record::{convert_shapes_to_vec_of, HasShapeType, ReadableShape};
 pub use record::{Multipoint, MultipointM, MultipointZ};
@@ -62,7 +65,7 @@ pub use record::{Patch, Shape, NO_DATA};
 pub use record::{Point, PointM, PointZ};
 pub use record::{Polygon, PolygonM, PolygonRing, PolygonZ};
 pub use record::{Polyline, PolylineM, PolylineZ};
-pub use writer::Writer;
+pub use writer::{ShapeWriter, Writer};
 
 extern crate core;
 #[cfg(feature = "geo-types")]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -603,6 +603,8 @@ pub fn read_as<T: AsRef<Path>, S: ReadableShape, R: dbase::ReadableRecord>(path:
 
 /// Function to read all the Shapes in a file as a certain type
 ///
+/// It does not open the .dbf file.
+///
 /// Fails and return `Err(Error:MismatchShapeType)`
 ///
 ///  # Examples

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -157,7 +157,7 @@ pub(crate) fn ring_type_from_points_ordering<PointType: HasXY>(points: &[PointTy
 /// # fn main() -> Result<(), shapefile::Error>{
 /// use std::convert::TryFrom;
 /// use shapefile::Shape;
-/// let mut shapes = shapefile::read("tests/data/line.shp")?;
+/// let mut shapes = shapefile::read_shapes("tests/data/line.shp")?;
 /// let last_shape = shapes.pop().unwrap();
 /// let geometry = geo_types::Geometry::<f64>::try_from(last_shape);
 ///

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -333,7 +333,7 @@ impl RecordHeader {
 /// ```
 /// # fn main() -> Result<(), shapefile::Error> {
 /// use shapefile::{convert_shapes_to_vec_of, MultipointZ};
-/// let shapes = shapefile::read("tests/data/multipointz.shp")?;
+/// let shapes = shapefile::read_shapes("tests/data/multipointz.shp")?;
 /// let multipoints = convert_shapes_to_vec_of::<MultipointZ>(shapes);
 /// assert_eq!(multipoints.is_ok(), true);
 /// # Ok(())

--- a/src/record/multipoint.rs
+++ b/src/record/multipoint.rs
@@ -51,7 +51,7 @@ use geo_types;
 /// ```
 /// # #[cfg(feature = "geo-types")]
 /// # fn main() -> Result<(), shapefile::Error> {
-/// let mut multipoints = shapefile::read_as::<_, shapefile::Multipoint>("tests/data/multipoint.shp")?;
+/// let mut multipoints = shapefile::read_shapes_as::<_, shapefile::Multipoint>("tests/data/multipoint.shp")?;
 /// let geo_multipoint: geo_types::MultiPoint<f64> = multipoints.pop().unwrap().into();
 /// let multipoint = shapefile::Multipoint::from(geo_multipoint);
 /// # Ok(())

--- a/src/record/polygon.rs
+++ b/src/record/polygon.rs
@@ -208,7 +208,7 @@ impl<PointType: HasXY> From<Vec<PointType>> for PolygonRing<PointType> {
 /// ```
 /// # #[cfg(feature = "geo-types")]
 /// # fn main() -> Result<(), shapefile::Error>{
-/// let mut polygons = shapefile::read_as::<_, shapefile::PolygonM>("tests/data/polygonm.shp")?;
+/// let mut polygons = shapefile::read_shapes_as::<_, shapefile::PolygonM>("tests/data/polygonm.shp")?;
 /// let geo_polygon: geo_types::MultiPolygon<f64> = polygons.pop().unwrap().into();
 /// let polygon = shapefile::PolygonZ::from(geo_polygon);
 /// # Ok(())

--- a/src/record/polyline.rs
+++ b/src/record/polyline.rs
@@ -32,7 +32,7 @@ use geo_types;
 /// ```
 /// # #[cfg(feature = "geo-types")]
 /// # fn main() -> Result<(), shapefile::Error>{
-/// let mut polylines = shapefile::read_as::<_, shapefile::Polyline>("tests/data/line.shp")?;
+/// let mut polylines = shapefile::read_shapes_as::<_, shapefile::Polyline>("tests/data/line.shp")?;
 /// let geo_polyline: geo_types::MultiLineString<f64> = polylines.pop().unwrap().into();
 /// let polyline = shapefile::Polyline::from(geo_polyline);
 /// # Ok(())

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,9 +1,13 @@
-//! Module with the definition of the [Writer](struct.Writer.html) that allows writing shapefile
+//! Module with the definition of the [Writer] that allows writing shapefile
 //!
-//! It is recommended to create a `Writer` using its [from_path](struct.Writer.html#method.from_path) method
-//! to ensure that both the .shp and .shx files are created.
-//! Then use its [writes_shapes](struct.Writer.html#method.write_shapes) method to write the files.
-
+//! # Writer
+//!
+//! [Writer] is the struct that writes a complete shapefile (_.shp_, _.shx_, _.dbf_).
+//!
+//! # ShapeWriter
+//!
+//! The [ShapeWriter] can be used if you only want to write the .shp
+//! and .shx files, however since it does not write the .dbf file, it is not recommended.
 use std::io::{BufWriter, Write};
 
 use header;
@@ -14,6 +18,7 @@ use Error;
 
 use byteorder::{BigEndian, WriteBytesExt};
 use reader::ShapeIndex;
+use dbase::{TableWriterBuilder};
 
 pub(crate) fn f64_min(a: f64, b: f64) -> f64 {
     if a < b {
@@ -49,26 +54,38 @@ fn write_index_file<T: Write>(
     Ok(())
 }
 
-/// struct that writes the shapes
-pub struct Writer<T: Write> {
-    pub dest: T,
-    index_dest: Option<T>,
-    dbase_dest: Option<T>,
+/// struct that handles the writing of the .shp
+/// and (optionally) the .idx
+///
+/// The recommended way to create a ShapeWriter by using [ShapeWriter::from_path]
+///
+/// # Important
+///
+/// As this writer does not write the _.dbf_, it does not write what is considered
+/// a complete (thus valid) shapefile.
+pub struct ShapeWriter<T: Write> {
+    shp_dest: T,
+    shx_dest: Option<T>,
 }
 
-impl<T: Write> Writer<T> {
+impl<T: Write> ShapeWriter<T> {
     /// Creates a writer that can be used to write a new shapefile.
     ///
     /// The `dest` argument is only for the .shp
-    pub fn new(dest: T) -> Self {
+    pub fn new(shp_dest: T) -> Self {
         Self {
-            dest,
-            index_dest: None,
-            dbase_dest: None,
+            shp_dest,
+            shx_dest: None,
         }
     }
 
-    //TODO This method should move as calling it twice would produce a shitty file
+    pub fn with_shx(shp_dest: T, shx_dest: T) -> Self {
+        Self {
+            shp_dest,
+            shx_dest: Some(shx_dest)
+        }
+    }
+
     /// Writes the shapes to the file
     ///
     /// # Examples
@@ -76,7 +93,7 @@ impl<T: Write> Writer<T> {
     /// ```
     /// # fn main() -> Result<(), shapefile::Error> {
     /// use shapefile::Point;
-    /// let mut writer = shapefile::Writer::from_path("points.shp")?;
+    /// let mut writer = shapefile::ShapeWriter::from_path("points.shp")?;
     /// let points = vec![Point::new(0.0, 0.0), Point::new(1.0, 0.0), Point::new(2.0, 0.0)];
     ///
     /// writer.write_shapes(&points)?;
@@ -87,7 +104,7 @@ impl<T: Write> Writer<T> {
     /// ```
     /// # fn main() -> Result<(), shapefile::Error> {
     /// use shapefile::{Point, Polyline};
-    /// let mut writer = shapefile::Writer::from_path("polylines.shp")?;
+    /// let mut writer = shapefile::ShapeWriter::from_path("polylines.shp")?;
     /// let points = vec![Point::new(0.0, 0.0), Point::new(1.0, 0.0), Point::new(2.0, 0.0)];
     /// let polyline = Polyline::new(points);
     ///
@@ -95,7 +112,7 @@ impl<T: Write> Writer<T> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn write_shapes<S: EsriShape>(&mut self, shapes: &[S]) -> Result<(), Error> {
+    pub fn write_shapes<S: EsriShape>(mut self, shapes: &[S]) -> Result<(), Error> {
         let mut file_length = header::HEADER_SIZE as usize;
         for shape in shapes {
             file_length += 2 * std::mem::size_of::<i32>(); // record_header
@@ -116,7 +133,7 @@ impl<T: Write> Writer<T> {
         };
 
         let mut pos = header::HEADER_SIZE / 2;
-        header.write_to(&mut self.dest)?;
+        header.write_to(&mut self.shp_dest)?;
         let mut shapes_index = Vec::<ShapeIndex>::with_capacity(shapes.len());
         for (i, shape) in (1..).zip(shapes) {
             //TODO Check record size < i32_max ?
@@ -131,69 +148,141 @@ impl<T: Write> Writer<T> {
                 record_size: record_size as i32,
             });
 
-            rc_hdr.write_to(&mut self.dest)?;
-            shapetype.write_to(&mut self.dest)?;
-            shape.write_to(&mut self.dest)?;
+            rc_hdr.write_to(&mut self.shp_dest)?;
+            shapetype.write_to(&mut self.shp_dest)?;
+            shape.write_to(&mut self.shp_dest)?;
             pos += record_size as i32 + RecordHeader::SIZE as i32 / 2;
         }
 
-        if let Some(ref mut shx_dest) = &mut self.index_dest {
+        if let Some(ref mut shx_dest) = &mut self.shx_dest {
             write_index_file(shx_dest, &header, shapes_index)?;
         }
 
         Ok(())
     }
-
-    pub fn write_shapes_and_records<S: EsriShape>(
-        mut self,
-        shapes: &[S],
-        records: Vec<dbase::Record>,
-    ) -> Result<(), Error> {
-        if shapes.len() != records.len() {
-            panic!("The shapes and records vectors must have the same len");
-        }
-        self.write_shapes(&shapes)?;
-        if let Some(dbase_dest) = self.dbase_dest {
-            let dbase_writer = dbase::Writer::new(dbase_dest);
-            dbase_writer.write(&records)?;
-        }
-        Ok(())
-    }
-
-    /// Adds dest as the destination where the index file will be written
-    pub fn add_index_dest(&mut self, dest: T) {
-        self.index_dest = Some(dest);
-    }
-
-    /// Adds dest as the destination where the dbase content will be written
-    pub fn add_dbase_dest(&mut self, dest: T) {
-        self.dbase_dest = Some(dest);
-    }
 }
 
-impl Writer<BufWriter<File>> {
+impl ShapeWriter<BufWriter<File>> {
     /// Creates a new writer from a path.
     /// Creates both a .shp and .shx files
     ///
     ///
     /// # Examples
     ///
-    /// ```
-    /// let writer = shapefile::Writer::from_path("/dev/null");
+    /// ```no_run
+    /// let writer = shapefile::ShapeWriter::from_path("new_file.shp");
     /// ```
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         let shp_path = path.as_ref().to_path_buf();
         let shx_path = shp_path.with_extension("shx");
-        let dbf_path = shp_path.with_extension("dbf");
 
         let shp_file = BufWriter::new(File::create(shp_path)?);
         let shx_file = BufWriter::new(File::create(shx_path)?);
-        let dbf_file = BufWriter::new(File::create(dbf_path)?);
 
-        let mut writer = Self::new(shp_file);
-        writer.add_index_dest(shx_file);
-        writer.add_dbase_dest(dbf_file);
+        Ok(Self::with_shx(shp_file,shx_file))
+    }
+}
 
-        Ok(writer)
+/// The Writer writes a complete shapefile that is, it
+/// writes the 3 mandatory files (.shp, .shx, .dbf)
+///
+/// The recommended way to create a new shapefile is via the
+/// [Writer::from_path] or [Writer::from_path_with_info] associated functions.
+///
+/// # Examples
+///
+/// To create a Writer that writes a .dbf file that has the same
+/// structure as .dbf read earlier you will have to do:
+///
+/// ```
+/// # fn main() -> Result<(), shapefile::Error> {
+/// let mut reader = shapefile::Reader::from_path("tests/data/multipatch.shp")?;
+/// let shape_records = reader.read()?;
+/// let table_info = reader.into_table_info();
+///
+/// let writer = shapefile::Writer::from_path_with_info("new_multipatch.shp", table_info);
+///
+/// # std::fs::remove_file("new_multipatch.shp")?;
+/// # std::fs::remove_file("new_multipatch.shx")?;
+/// # std::fs::remove_file("new_multipatch.dbf")?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct Writer<T: Write> {
+    shape_writer: ShapeWriter<T>,
+    dbase_writer: dbase::TableWriter<T>
+}
+
+impl<T: Write> Writer<T> {
+    /// Creates a new writer using the provided ShapeWriter and TableWriter
+    ///
+    /// # Example
+    ///
+    /// Creating a Writer that writes to in memory buffers.
+    ///
+    /// ```
+    /// # fn main() -> Result<(), shapefile::Error> {
+    /// use std::convert::TryInto;
+    /// let mut shp_dest = std::io::Cursor::new(Vec::<u8>::new());
+    /// let mut shx_dest = std::io::Cursor::new(Vec::<u8>::new());
+    /// let mut dbf_dest = std::io::Cursor::new(Vec::<u8>::new());
+    ///
+    /// let shape_writer = shapefile::ShapeWriter::with_shx(&mut shp_dest, &mut shx_dest);
+    /// let dbase_writer = dbase::TableWriterBuilder::new()
+    ///     .add_character_field("Name".try_into().unwrap(), 50)
+    ///     .build_with_dest(&mut dbf_dest);
+    ///
+    /// let shape_writer = shapefile::Writer::new(shape_writer, dbase_writer);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn new(shape_writer: ShapeWriter<T>, dbase_writer: dbase::TableWriter<T>) -> Self {
+        Self {
+            shape_writer,
+            dbase_writer
+        }
+    }
+
+    // TODO once we get the ability to write shapes and records 'iteratively' the input to
+    //      this function could be IntoIterator<Item=(S, R)>
+    pub fn write_shapes_and_records<S: EsriShape, R: dbase::WritableRecord>(self, shapes: &[S], records: &[R]) -> Result<(), Error> {
+        if shapes.len() != records.len() {
+            panic!("There must be has many shapes as there are records");
+        }
+        self.shape_writer.write_shapes(shapes)?;
+        self.dbase_writer.write(records)?;
+        Ok(())
+    }
+}
+
+impl Writer<BufWriter<File>> {
+    /// Creates all the files needed for the shapefile to be complete (.shp, .shx, .dbf)
+    ///
+    /// ```
+    /// # fn main() -> Result<(), shapefile::Error> {
+    /// use std::convert::TryInto;
+    /// let table_builder = dbase::TableWriterBuilder::new()
+    ///     .add_character_field("name".try_into().unwrap(), 50);
+    /// let writer = shapefile::Writer::from_path("new_cities.shp", table_builder)?;
+    /// # std::fs::remove_file("new_cities.shp")?;
+    /// # std::fs::remove_file("new_cities.shx")?;
+    /// # std::fs::remove_file("new_cities.dbf")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn from_path<P: AsRef<Path>>(path: P, table_builder: TableWriterBuilder) -> Result<Self, Error> {
+        Ok(Self {
+            shape_writer: ShapeWriter::from_path(path.as_ref())?,
+            dbase_writer: table_builder.build_with_file_dest(
+                path.as_ref().with_extension("dbf"))?
+        })
+    }
+
+    pub fn from_path_with_info<P: AsRef<Path>>(path: P, table_info: dbase::TableInfo) -> Result<Self, Error> {
+        Ok(Self {
+            shape_writer: ShapeWriter::from_path(path.as_ref())?,
+            dbase_writer: dbase::TableWriterBuilder::from_table_info(table_info)
+                .build_with_file_dest(path.as_ref().with_extension("dbf"))?
+        })
     }
 }

--- a/tests/read_with_index.rs
+++ b/tests/read_with_index.rs
@@ -3,8 +3,8 @@ extern crate shapefile;
 mod testfiles;
 
 #[test]
-fn test_line() {
-    let mut reader = shapefile::Reader::from_path(testfiles::LINE_PATH).unwrap();
+fn test_line_read_nth() {
+    let mut reader = shapefile::ShapeReader::from_path(testfiles::LINE_PATH).unwrap();
 
     if let Some(shape) = reader.read_nth_shape(0) {
         let shp = shape.unwrap();

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -2,7 +2,8 @@ extern crate shapefile;
 
 mod testfiles;
 
-use shapefile::{Point, Polygon, PolygonRing, Polyline, Writer};
+use shapefile::{Point, Polygon, PolygonRing, Polyline};
+use shapefile::writer::ShapeWriter;
 
 fn read_a_file(path: &str) -> std::io::Result<Vec<u8>> {
     use std::io::Read;
@@ -18,8 +19,7 @@ fn single_point() {
     let point = Point::new(122.0, 37.0);
     let mut shp: Vec<u8> = vec![];
     let mut shx: Vec<u8> = vec![];
-    let mut writer = Writer::new(&mut shp);
-    writer.add_index_dest(&mut shx);
+    let writer = ShapeWriter::with_shx(&mut shp, &mut shx);
     writer.write_shapes(&vec![point]).unwrap();
 
     let expected = read_a_file(testfiles::POINT_PATH);
@@ -45,8 +45,7 @@ fn multi_line() {
     ]);
     let mut shp: Vec<u8> = vec![];
     let mut shx: Vec<u8> = vec![];
-    let mut writer = Writer::new(&mut shp);
-    writer.add_index_dest(&mut shx);
+    let writer = ShapeWriter::with_shx(&mut shp, &mut shx);
     writer.write_shapes(&vec![point]).unwrap();
 
     let expected = read_a_file(testfiles::LINE_PATH);
@@ -78,8 +77,7 @@ fn polygon_inner() {
     ]);
     let mut shp: Vec<u8> = vec![];
     let mut shx: Vec<u8> = vec![];
-    let mut writer = Writer::new(&mut shp);
-    writer.add_index_dest(&mut shx);
+    let writer = ShapeWriter::with_shx(&mut shp, &mut shx);
     writer.write_shapes(&vec![point]).unwrap();
 
     let expected = read_a_file(testfiles::POLYGON_HOLE_PATH);
@@ -113,8 +111,7 @@ fn polygon_inner_is_correctly_reordered() {
     ]);
     let mut shp: Vec<u8> = vec![];
     let mut shx: Vec<u8> = vec![];
-    let mut writer = Writer::new(&mut shp);
-    writer.add_index_dest(&mut shx);
+    let writer = ShapeWriter::with_shx(&mut shp, &mut shx);
     writer.write_shapes(&vec![point]).unwrap();
 
     let expected = read_a_file(testfiles::POLYGON_HOLE_PATH);


### PR DESCRIPTION
The various `iter_shapes_as` `iter_shapes_and_records_as`
now take `&mut self` instead of `self` to be able
to use `dbase::RecordIterator`.

Move the purely shapefile related reader in a new
`ShapeReader` struct and use it in the `Reader` struct.
`ShapeReader` may be useful for projects wich don't care about dbf

Same thing for writing
`ShapeWriter is a new struct that handle the writing of the shp and shx.

The `Reader` has a handle to a `ShapeWriter` and `dbase::TableWriter`.

Things to decide:
 - Should the `dbase::Reader` of the  `Reader` be mandatory and not an `Option` anymore ?
   Meaning `Reader::from_path` would error_out if the `.dbf`` is not found.
  
  The `dbase::TableWriter` is mandaoty to create a new `shapefile::Writer` because the esri spec
  seems to say that `.dbf` are mandaroty (and should contain at least on field), so by "symmetry" the
  `shapefile::Reader` should also require a `dbf` file

TODO:
- [x] Creating a `Writer` Using the `dbf` info from a `Reader`.
- [x] Documentation
- [ ] Release new dbase version & update Cargo.toml to use it


Writing shapes / records one by one as oppposed to all at once  should be added in another pr

Addresses #16 
