### PR TITLE
Use a second generic parameter in `with_shx`

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -234,7 +234,10 @@ impl<T: Read> ShapeReader<T> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn with_shx(mut source: T, shx_source: T) -> Result<Self, Error> {
+    pub fn with_shx<ShxSource>(mut source: T, shx_source: ShxSource) -> Result<Self, Error>
+    where
+        ShxSource: Read,
+    {
         let shapes_index = Some(read_index_file(shx_source)?);
         let header = header::Header::read_from(&mut source)?;
 


### PR DESCRIPTION
This change allows a different reader type to be used as the `ShxSource` which is useful sometimes.