### PR TITLE
Bump dependency on dbase to version 0.5.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 
 [dependencies]
 byteorder = "1.2.7"
-dbase = "0.4.0"
+dbase = "0.5.0"
 geo-types = {version = ">=0.4.0, <0.8.0", optional = true}
 
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -99,7 +99,6 @@ impl Header {
 mod tests {
     use super::*;
 
-    use byteorder::WriteBytesExt;
     use std::io::{Seek, SeekFrom};
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,6 @@ pub mod record;
 pub mod writer;
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use std::convert::From;
 use std::fmt;
 use std::io::{Read, Write};
 

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -20,7 +20,6 @@ pub use multipoint::{Multipoint, MultipointM, MultipointZ};
 pub use point::{Point, PointM, PointZ};
 pub use polygon::{Polygon, PolygonM, PolygonRing, PolygonZ};
 pub use polyline::{Polyline, PolylineM, PolylineZ};
-use std::convert::TryFrom;
 use traits::HasXY;
 
 #[cfg(feature = "geo-types")]


### PR DESCRIPTION
If released, this would allow downstream project to migrate off the outdated dbase version 0.4.0.

(The code changes are admittedly unrelated and just required to resolve warnings the current rustc version emits.)