### PR TITLE
Don't always seek if a .shx was given

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -136,10 +136,12 @@ impl<'a, T: Read + Seek, S: ReadableShape> Iterator for ShapeIterator<'a, T, S> 
                 // as some shapes may not be stored sequentially and may contain 'garbage'
                 // bytes between them
                 let start_pos = shapes_indices.next()?.offset * 2;
-                if let Err(err) = self.source.seek(SeekFrom::Start(start_pos as u64)) {
-                    return Some(Err(err.into()));
+                if start_pos != self.current_pos as i32 {
+                    if let Err(err) = self.source.seek(SeekFrom::Start(start_pos as u64)) {
+                        return Some(Err(err.into()));
+                    }
+                    self.current_pos = start_pos as usize;
                 }
-                self.current_pos = start_pos as usize;
             }
             let (hdr, shape) = match read_one_shape_as::<T, S>(self.source) {
                 Err(e) => return Some(Err(e)),


### PR DESCRIPTION
If a .shx file was given or found we would always use it to seek to the position it contained.

However calling seek on a BufRead discards the buffer even if we seek to the position is at leading to a performance loss due to I/O.

So we now only seek if we need to