### PR TITLE
Add size_hint for Shapefile and parts iterators

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -152,6 +152,13 @@ impl<'a, T: Read + Seek, S: ReadableShape> Iterator for ShapeIterator<'a, T, S> 
             Some(Ok(shape))
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.shapes_indices
+            .as_ref()
+            .map(|s| s.size_hint())
+            .unwrap_or((0, None))
+    }
 }
 
 pub struct ShapeRecordIterator<

--- a/src/record/io.rs
+++ b/src/record/io.rs
@@ -175,6 +175,15 @@ impl<'a> Iterator for PartIndexIter<'a> {
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.num_points < 0 {
+            (0, None)
+        } else {
+            let remaining = self.parts_indices.len() - self.current_part_index;
+            (remaining, Some(remaining))
+        }
+    }
 }
 
 pub(crate) struct MultiPartShapeReader<'a, PointType, R: Read> {

--- a/tests/read_with_index.rs
+++ b/tests/read_with_index.rs
@@ -15,3 +15,14 @@ fn test_line_read_nth() {
 
     assert_eq!(reader.read_nth_shape(1).is_none(), true);
 }
+
+#[test]
+fn test_size_hint() {
+    let mut reader = shapefile::ShapeReader::from_path(testfiles::LINE_PATH).unwrap();
+    let mut iter = reader.iter_shapes();
+    assert_eq!(iter.size_hint(), (1, Some(1)));
+    iter.next();
+
+    // size_hint must return the remaining length and not the entire length at the beginning.
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+}


### PR DESCRIPTION
When there is an index the iterator can know how many shapes are contained in the file.