### PR TITLE
Add `into_geo_traits()` to `Polygon`, `PolygonM`, and `PolygonZ`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# unreleased
+- Added `Polygon::try_into_geo_traits()`, which converts a polygon to an object that implements
+  `geo_traits::PolygonTrait`.
+- Converting to `geo_types::Polygon` is now fallible (i.e. `TryFrom`, not `From`).
+
 # 0.7.0
  - Bumped dbase to 0.6
  - Added `yore` and `encoding_rs` features which are forwarded to `dbase`

--- a/src/geo_traits_impl.rs
+++ b/src/geo_traits_impl.rs
@@ -489,8 +489,10 @@ impl MultiLineStringTrait for PolylineZ {
 
 pub struct MultiPolygon(Vec<Polygon>);
 
-impl From<crate::Polygon> for MultiPolygon {
-    fn from(geom: crate::Polygon) -> Self {
+impl TryFrom<crate::Polygon> for MultiPolygon {
+    type Error = crate::Error;
+
+    fn try_from(geom: crate::Polygon) -> Result<Self, Self::Error> {
         let mut last_poly = None;
         let mut polygons = Vec::new();
         for ring in geom.into_inner() {
@@ -508,12 +510,7 @@ impl From<crate::Polygon> for MultiPolygon {
                     if let Some(poly) = last_poly.as_mut() {
                         poly.inner.push(points);
                     } else {
-                        panic!("inner ring without a previous outer ring");
-                        // This is the strange (?) case: inner ring without a previous outer ring
-                        // polygons.push(geo_types::Polygon::<f64>::new(
-                        //     LineString::<f64>::from(Vec::<Coordinate<f64>>::new()),
-                        //     vec![LineString::from(interior)],
-                        // ));
+                        return Err(crate::Error::OrphanedInnerRing);
                     }
                 }
             }
@@ -523,7 +520,7 @@ impl From<crate::Polygon> for MultiPolygon {
             polygons.push(poly);
         }
 
-        Self(polygons)
+        Ok(Self(polygons))
     }
 }
 
@@ -541,8 +538,10 @@ impl MultiPolygonTrait for MultiPolygon {
 
 pub struct MultiPolygonM(Vec<PolygonM>);
 
-impl From<crate::PolygonM> for MultiPolygonM {
-    fn from(geom: crate::PolygonM) -> Self {
+impl TryFrom<crate::PolygonM> for MultiPolygonM {
+    type Error = crate::Error;
+
+    fn try_from(geom: crate::PolygonM) -> Result<Self, Self::Error> {
         let mut last_poly = None;
         let mut polygons = Vec::new();
         for ring in geom.into_inner() {
@@ -560,12 +559,7 @@ impl From<crate::PolygonM> for MultiPolygonM {
                     if let Some(poly) = last_poly.as_mut() {
                         poly.inner.push(points);
                     } else {
-                        panic!("inner ring without a previous outer ring");
-                        // This is the strange (?) case: inner ring without a previous outer ring
-                        // polygons.push(geo_types::Polygon::<f64>::new(
-                        //     LineString::<f64>::from(Vec::<Coordinate<f64>>::new()),
-                        //     vec![LineString::from(interior)],
-                        // ));
+                        return Err(crate::Error::OrphanedInnerRing);
                     }
                 }
             }
@@ -575,7 +569,7 @@ impl From<crate::PolygonM> for MultiPolygonM {
             polygons.push(poly);
         }
 
-        Self(polygons)
+        Ok(Self(polygons))
     }
 }
 
@@ -593,8 +587,10 @@ impl MultiPolygonTrait for MultiPolygonM {
 
 pub struct MultiPolygonZ(Vec<PolygonZ>);
 
-impl From<crate::PolygonZ> for MultiPolygonZ {
-    fn from(geom: crate::PolygonZ) -> Self {
+impl TryFrom<crate::PolygonZ> for MultiPolygonZ {
+    type Error = crate::Error;
+
+    fn try_from(geom: crate::PolygonZ) -> Result<Self, Self::Error> {
         let mut last_poly = None;
         let mut polygons = Vec::new();
         for ring in geom.into_inner() {
@@ -612,12 +608,7 @@ impl From<crate::PolygonZ> for MultiPolygonZ {
                     if let Some(poly) = last_poly.as_mut() {
                         poly.inner.push(points);
                     } else {
-                        panic!("inner ring without a previous outer ring");
-                        // This is the strange (?) case: inner ring without a previous outer ring
-                        // polygons.push(geo_types::Polygon::<f64>::new(
-                        //     LineString::<f64>::from(Vec::<Coordinate<f64>>::new()),
-                        //     vec![LineString::from(interior)],
-                        // ));
+                        return Err(crate::Error::OrphanedInnerRing);
                     }
                 }
             }
@@ -627,7 +618,7 @@ impl From<crate::PolygonZ> for MultiPolygonZ {
             polygons.push(poly);
         }
 
-        Self(polygons)
+        Ok(Self(polygons))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,12 @@ pub enum Error {
         actual: ShapeType,
     },
     InvalidShapeRecordSize,
+    /// The Polygon shape read from the file contains an orphaned inner ring,
+    /// which doesn't have the corresponding outer ring.
+    #[cfg(feature = "geo-types")]
+    OrphanedInnerRing,
+    #[cfg(feature = "geo-types")]
+    UnsupportedConversion,
     DbaseError(dbase::Error),
     MissingDbf,
     MissingIndexFile,
@@ -139,6 +145,10 @@ impl fmt::Display for Error {
                 f,
                 "The requested type: '{requested}' does not correspond to the actual shape type: '{actual}'"
             ),
+            #[cfg(feature = "geo-types")]
+            Error::OrphanedInnerRing => write!(f, "Inner ring without a previous outer ring"),
+            #[cfg(feature = "geo-types")]
+            Error::UnsupportedConversion => writeln!(f, "The conversion is not supported"),
             e => write!(f, "{e:?}"),
         }
     }

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -431,12 +431,12 @@ impl_to_way_conversion!(Shape::Multipatch <=> Multipatch);
 /// their geo_types counter parts can fail. And the NullShape has no equivalent Geometry;
 #[cfg(feature = "geo-types")]
 impl TryFrom<Shape> for geo_types::Geometry<f64> {
-    type Error = &'static str;
+    type Error = Error;
 
     fn try_from(shape: Shape) -> Result<Self, Self::Error> {
         use geo_types::Geometry;
         match shape {
-            Shape::NullShape => Err("Cannot convert NullShape into any geo_types Geometry"),
+            Shape::NullShape => Err(Error::UnsupportedConversion),
             Shape::Point(point) => Ok(Geometry::Point(geo_types::Point::from(point))),
             Shape::PointM(point) => Ok(Geometry::Point(geo_types::Point::from(point))),
             Shape::PointZ(point) => Ok(Geometry::Point(geo_types::Point::from(point))),
@@ -449,15 +449,15 @@ impl TryFrom<Shape> for geo_types::Geometry<f64> {
             Shape::PolylineZ(polyline) => Ok(Geometry::MultiLineString(
                 geo_types::MultiLineString::<f64>::from(polyline),
             )),
-            Shape::Polygon(polygon) => Ok(Geometry::MultiPolygon(
-                geo_types::MultiPolygon::<f64>::from(polygon),
-            )),
-            Shape::PolygonM(polygon) => Ok(Geometry::MultiPolygon(
-                geo_types::MultiPolygon::<f64>::from(polygon),
-            )),
-            Shape::PolygonZ(polygon) => Ok(Geometry::MultiPolygon(
-                geo_types::MultiPolygon::<f64>::from(polygon),
-            )),
+            Shape::Polygon(polygon) => {
+                geo_types::MultiPolygon::<f64>::try_from(polygon).map(Geometry::MultiPolygon)
+            }
+            Shape::PolygonM(polygon) => {
+                geo_types::MultiPolygon::<f64>::try_from(polygon).map(Geometry::MultiPolygon)
+            }
+            Shape::PolygonZ(polygon) => {
+                geo_types::MultiPolygon::<f64>::try_from(polygon).map(Geometry::MultiPolygon)
+            }
             Shape::Multipoint(multipoint) => Ok(Geometry::MultiPoint(
                 geo_types::MultiPoint::<f64>::from(multipoint),
             )),


### PR DESCRIPTION
Originally suggested in https://github.com/tmontaigu/shapefile-rs/pull/38#issuecomment-2560436702

I tried to replace `geo_types::Geometry` with the geo-traits crate, and found it difficult due to the above reason. This pull request should enable the replacement like this:

https://github.com/yutannihilation/ksj2gp/pull/132/files#diff-0333a9b7de96f364c33716ebb03b82cb8c4ce5c56d38865339add82c3d7c6bbc

This pull request adds `into_geo_traits()` method which returns an opaque struct `MultiPolygon` and alike. Originally, `as_geo_traits()` was suggested, but as this is consuming `self` and does some allocation, I think `into` fix better.

Also, this pull request replaces the `From` conversion to `MultiPolygon` with `TryFrom`, which was also suggested.